### PR TITLE
Add variable to specify elasticsearch-service in kibana-deployment

### DIFF
--- a/build/kibana/config/kibana-oss.yml
+++ b/build/kibana/config/kibana-oss.yml
@@ -8,6 +8,6 @@ elasticsearch.customHeaders: { x-proxy-roles: admin, x-scope-orgid: xyz, X-Forwa
 elasticsearch.ssl.verificationMode: none
 
 own_home.proxy_user_header: x-scope-orgid
-own_home.elasticsearch.url: "${ELASTICSEARCH_URL}" # this will help in passing the elasticsearch service from kibana deployment
+own_home.elasticsearch.url: "${OWN_HOME_ELASTICSEARCH_URL}" # this will help in passing the elasticsearch service from kibana deployment
 
 elasticsearch.requestHeadersWhitelist: [authorization, x-scope-orgid]

--- a/build/kibana/config/kibana-oss.yml
+++ b/build/kibana/config/kibana-oss.yml
@@ -11,3 +11,6 @@ own_home.proxy_user_header: x-scope-orgid
 own_home.elasticsearch.url: "${OWN_HOME_ELASTICSEARCH_URL}" # this will help in passing the elasticsearch service from kibana deployment
 
 elasticsearch.requestHeadersWhitelist: [authorization, x-scope-orgid]
+
+xpack.apm.enabled: false
+xpack.monitoring.ui.enabled: false

--- a/build/kibana/config/kibana-oss.yml
+++ b/build/kibana/config/kibana-oss.yml
@@ -8,6 +8,6 @@ elasticsearch.customHeaders: { x-proxy-roles: admin, x-scope-orgid: xyz, X-Forwa
 elasticsearch.ssl.verificationMode: none
 
 own_home.proxy_user_header: x-scope-orgid
-own_home.elasticsearch.url: http://elasticsearch-logging:9200
+own_home.elasticsearch.url: "${ELASTICSEARCH_URL}" # this will help in passing the elasticsearch service from kibana deployment
 
 elasticsearch.requestHeadersWhitelist: [authorization, x-scope-orgid]


### PR DESCRIPTION
This PR adds `ELASTICSEARCH_URL` which can be used as env in kibana deployment to specify the elasticsearch service.

Signed-off-by: Shivesh Abhishek <shivesh.abhishek@mayadata.io>