### PR TITLE
Fix permission denied error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ ENV PATH=/usr/share/kibana/bin:$PATH
 COPY ./own_home-6.4.0.zip /usr/share/
 RUN /usr/share/kibana/bin/kibana-plugin install file:///usr/share/own_home-6.4.0.zip
 
+# remove optimize directory from root permission as it is not being deleted by kibana and gives permission denied error
+# during the server optimizer run
+# This error occured when plugin is disabled from kibana config (xpack.apm.enabled: false)
+RUN rm -rf /usr/share/kibana/optimize/bundles
+
 # Set some Kibana configuration defaults.
 COPY --chown=1000:0 ./build/kibana/config/kibana-oss.yml /usr/share/kibana/config/kibana.yml
 


### PR DESCRIPTION
- In dockerfile when own home plugin is installed it goes through the optimizer process and this command is ran using root user and hence creates the file inside optimizer/bundles with root permissions.
- After the image is build and when we try to run that image it again goes through the optimizer due to changes in the kibana config (disabling xpack features/plugins) and tries to delete some of the files already present inside the directory (/usr/share/kibana/optimize/bundles/)  which is denied, as current user is kibana.

```
FATAL { Error: EACCES: permission denied, rmdir '/usr/share/kibana/optimize/bundles/src/ui'
  errno: -13,
  code: 'EACCES',
  syscall: 'rmdir',
  path: '/usr/share/kibana/optimize/bundles/src/ui' }
```

Signed-off-by: Sumit Lalwani <sumit.lalwani97@gmail.com>